### PR TITLE
List utils post-processors

### DIFF
--- a/question_framework/post_process/post_process.py
+++ b/question_framework/post_process/post_process.py
@@ -51,7 +51,8 @@ def mapped_to(*fs: Callable) -> Callable[[str], List[Any]]:
     """
     def mapper(ans: str, **kw):
         items = as_list(ans)
-        assert len(items) == len(fs), 'Key & Input lists have mismatched lengths'
+        if len(items) != len(fs):
+            raise ValueError('Key & Input lists have mismatched lengths')
         items = (f(i) for i, f in zip(items, fs))
         return list(items)
     return mapper

--- a/question_framework/post_process/post_process.py
+++ b/question_framework/post_process/post_process.py
@@ -4,6 +4,19 @@ from functools import partial
 import re
 
 
+def ip_range_to_list(x):
+    def ip_range_generator(ip1, ip2):
+        ip1 = int(ip_address(ip1))
+        ip2 = int(ip_address(ip2))
+        ip1, ip2 = min(ip1, ip2), max(ip1, ip2)
+        for i in range(ip1, ip2 + 1):
+            yield ip_address(i)
+
+    ip1, ip2 = x.replace(" ", "").split("-")
+
+    return ip_range_generator(ip1, ip2)
+
+
 def as_list(ans: str, sep: str = ',', f: Optional[Callable[[str], Any]] = None) -> List[Any]:
     """
     Parse list elements and and optionally apply a transformer to each element.
@@ -42,19 +55,6 @@ def mapped_to(*fs: Callable) -> Callable[[str], List[Any]]:
         items = (f(i) for i, f in zip(items, fs))
         return list(items)
     return mapper
-
-
-def ip_range_to_list(x):
-    def ip_range_generator(ip1, ip2):
-        ip1 = int(ip_address(ip1))
-        ip2 = int(ip_address(ip2))
-        ip1, ip2 = min(ip1, ip2), max(ip1, ip2)
-        for i in range(ip1, ip2 + 1):
-            yield ip_address(i)
-
-    ip1, ip2 = x.replace(" ", "").split("-")
-
-    return ip_range_generator(ip1, ip2)
 
 
 def as_int_range(ans: str) -> range:

--- a/question_framework/post_process/post_process.py
+++ b/question_framework/post_process/post_process.py
@@ -62,21 +62,21 @@ def as_int_range(ans: str) -> range:
     """
     Compute an integer range from a string representation. Several options:
     dash notation: 3 - 5 (only positive values)
-    python slice notation: <start>?:<end>:<step>?
+    python slice notation: :3 (start implied to be 0), 3:4 (normal), 3:55:2 (with step)
     natural language: 'from 3 to 5' or '-55 to 55'
     """
     ans = ans.strip()
-    if re.match(r'[0-9]+\s*-\s*[0-9]+', ans):
+    if re.match(r'^\s*\d+\s*-\s*\d+$', ans):
         start, end = ans.split('-')
         start = start.strip()
         end = end.strip()
         return range(int(start), int(end))
-    if ':' in ans:
+    if re.match(r'^(-?\d+)?:-?\d+(:-?\d+)?$', ans):
         start, end, *step = ans.split(':')
         start = int(start or 0)
         step = int(step and step[0] or 1)
         return range(start, int(end), step)
-    if re.match(r'(from\s)?\s*-?[0-9]+\s+to\s+-?[0-9]+', ans, flags=re.IGNORECASE):
+    if re.match(r'^(from\s)?\s*-?\d+\s+to\s+-?\d+$', ans, flags=re.IGNORECASE):
         *_, start, _, end = ans.split()
         start = int(start)
         end = int(end)

--- a/question_framework/post_process/post_process.py
+++ b/question_framework/post_process/post_process.py
@@ -2,7 +2,6 @@ from ipaddress import ip_address
 from typing import Callable, List, Optional, Any
 from functools import partial
 import re
-import ast
 
 
 def as_list(ans: str, sep: str = ',', f: Optional[Callable[[str], Any]] = None) -> List[Any]:

--- a/question_framework/post_process/post_process.py
+++ b/question_framework/post_process/post_process.py
@@ -63,7 +63,7 @@ def as_int_range(ans: str) -> range:
     Compute an integer range from a string representation. Several options:
     dash notation: 3 - 5 (only positive values)
     python slice notation: <start>?:<end>:<step>?
-    natural language: from '3 to 5' or '-55 to 55'
+    natural language: 'from 3 to 5' or '-55 to 55'
     """
     ans = ans.strip()
     if re.match(r'[0-9]+\s*-\s*[0-9]+', ans):

--- a/question_framework/post_process/post_process.py
+++ b/question_framework/post_process/post_process.py
@@ -19,7 +19,7 @@ def ip_range_to_list(x):
 
 def as_list(ans: str, sep: str = ',', f: Optional[Callable[[str], Any]] = None) -> List[Any]:
     """
-    Parse list elements and and optionally apply a transformer to each element.
+    Parse list elements and optionally apply a transformer to each element.
     This allows you to parse things directly as the type they should be, e.g. integers:
     as_list("3, 4", f=int) == [3, 4]
     """

--- a/tests/test_post_process.py
+++ b/tests/test_post_process.py
@@ -1,3 +1,5 @@
+import sys
+sys.path.append('..')
 from question_framework.post_process import *
 
 
@@ -57,3 +59,4 @@ if __name__ == "__main__":
     test_as_list()
     test_as_list_of()
     test_as_int_range()
+    test_mapped_to()

--- a/tests/test_post_process.py
+++ b/tests/test_post_process.py
@@ -1,0 +1,2 @@
+def test_as_int_range():
+  

--- a/tests/test_post_process.py
+++ b/tests/test_post_process.py
@@ -1,5 +1,3 @@
-import sys
-sys.path.append('..')
 from question_framework.post_process import *
 
 
@@ -27,6 +25,11 @@ def test_mapped_to():
 
     assert mapped_to(int, float, str)("34, 34.5, jon") == [34, 34.5, "jon"]
 
+    try:
+        mapped_to(int, float)("34, 34, 34")
+    except ValueError as ve:
+        assert str(ve).endswith('mismatched lengths')
+
     class IntValue(Value):
         def __init__(self, value): super().__init__(int(value))
     class FloatValue(Value):
@@ -53,10 +56,3 @@ def test_as_int_range():
     assert as_int_range("from -333 to -28") == range(-333, -28, 1)
     assert as_int_range("from -333 to 28") == range(-333, 28, 1)
     assert as_int_range("333 to 2833") == range(333, 2833, 1)
-
-
-if __name__ == "__main__":
-    test_as_list()
-    test_as_list_of()
-    test_as_int_range()
-    test_mapped_to()

--- a/tests/test_post_process.py
+++ b/tests/test_post_process.py
@@ -1,5 +1,3 @@
-import sys
-sys.path.append('..')
 from question_framework.post_process import *
 
 

--- a/tests/test_post_process.py
+++ b/tests/test_post_process.py
@@ -8,11 +8,35 @@ def test_as_list():
     assert as_list("3,4") == ["3", "4"]
     assert as_list("3 , 4 ") == ["3", "4"]
 
-    
+
+class Value:
+    def __init__(self, value):
+        self.value = value
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.value == other.value
+
+
 def test_as_list_of():
+
     assert as_list_of(int)("3, 4") == [3, 4]
     assert as_list_of(float)("3.5; 6", sep=";") == [3.5, 6.0]
-    
+    assert as_list_of(Value)("33, allo") == [Value("33"), Value("allo")]
+
+
+def test_mapped_to():
+
+    assert mapped_to(int, float, str)("34, 34.5, jon") == [34, 34.5, "jon"]
+
+    class IntValue(Value):
+        def __init__(self, value): super().__init__(int(value))
+    class FloatValue(Value):
+        def __init__(self, value): super().__init__(float(value))
+
+    assert mapped_to(IntValue, FloatValue, str)("34, 34.5, jon") == [
+        IntValue(34),
+        FloatValue(34.5),
+        "jon"
+    ]
 
 def test_as_int_range():
 
@@ -28,6 +52,7 @@ def test_as_int_range():
     assert as_int_range("from 333 to -28") == range(333, -28, -1)
     assert as_int_range("from -333 to -28") == range(-333, -28, 1)
     assert as_int_range("from -333 to 28") == range(-333, 28, 1)
+    assert as_int_range("333 to 2833") == range(333, 2833, 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_post_process.py
+++ b/tests/test_post_process.py
@@ -1,13 +1,36 @@
+import sys
+sys.path.append('..')
+from question_framework.post_process import *
 
 
 def test_as_list():
-    assert as_list("3 4") == ["3", "4"]
-    assert as_list("3 4 ") == ["3", "4"]
-    assert as_list("3  4 ") == ["3", "4"]
-    assert as_list("3, 4", sep=',') == ["3", "4"]
+    assert as_list("3, 4") == ["3", "4"]
+    assert as_list("3,4") == ["3", "4"]
+    assert as_list("3 , 4 ") == ["3", "4"]
 
     
 def test_as_list_of():
-    assert as_list_of(int)("3 4") == [3, 4]
+    assert as_list_of(int)("3, 4") == [3, 4]
     assert as_list_of(float)("3.5; 6", sep=";") == [3.5, 6.0]
     
+
+def test_as_int_range():
+
+    assert as_int_range("3-66") == range(3, 66)
+    assert as_int_range("0 - 0") == range(0)
+
+    assert as_int_range(":33:3") == range(0, 33, 3)
+    assert as_int_range(":33:") == range(0, 33)
+    assert as_int_range(":33") == range(0, 33)
+    assert as_int_range("0:33") == range(0, 33)
+    assert as_int_range("-28:33:") == range(-28, 33)
+
+    assert as_int_range("from 333 to -28") == range(333, -28, -1)
+    assert as_int_range("from -333 to -28") == range(-333, -28, 1)
+    assert as_int_range("from -333 to 28") == range(-333, 28, 1)
+
+
+if __name__ == "__main__":
+    test_as_list()
+    test_as_list_of()
+    test_as_int_range()

--- a/tests/test_post_process.py
+++ b/tests/test_post_process.py
@@ -1,2 +1,13 @@
-def test_as_int_range():
-  
+
+
+def test_as_list():
+    assert as_list("3 4") == ["3", "4"]
+    assert as_list("3 4 ") == ["3", "4"]
+    assert as_list("3  4 ") == ["3", "4"]
+    assert as_list("3, 4", sep=',') == ["3", "4"]
+
+    
+def test_as_list_of():
+    assert as_list_of(int)("3 4") == [3, 4]
+    assert as_list_of(float)("3.5; 6", sep=";") == [3.5, 6.0]
+    

--- a/tests/test_post_process.py
+++ b/tests/test_post_process.py
@@ -47,10 +47,10 @@ def test_as_int_range():
     assert as_int_range("0 - 0") == range(0)
 
     assert as_int_range(":33:3") == range(0, 33, 3)
-    assert as_int_range(":33:") == range(0, 33)
+    assert as_int_range(":33") == range(0, 33)
     assert as_int_range(":33") == range(0, 33)
     assert as_int_range("0:33") == range(0, 33)
-    assert as_int_range("-28:33:") == range(-28, 33)
+    assert as_int_range("-28:33") == range(-28, 33)
 
     assert as_int_range("from 333 to -28") == range(333, -28, -1)
     assert as_int_range("from -333 to -28") == range(-333, -28, 1)


### PR DESCRIPTION
Hi ! #4

Here are a few utils to parse list answers and make some type conversions while we're at it, hope you'll find it useful.

* `as_list_of(type)` allows you to convert all elements of one list to a given type;
* `mapped_to(*types)` allows you to choose the type for each expected field.

and 

* `as_int_range` allows you to parse an integer range answer in various formats, including a simple pattern in natural language.

Coming with their own tests in `tests/test_post_process.py`.