### PR TITLE
Changed f-strings to format methods

### DIFF
--- a/question_framework/question/question.py
+++ b/question_framework/question/question.py
@@ -22,9 +22,8 @@ class Question():
         return self.post_process(answer)
 
     def ask(self):
-        logger.debug(f"Question: {self.name}")
+        logger.debug("Question: {}".format(self.name))
         return {self.name: self.get_answer()}
-
 
 class RepeatedQuestion(Question):
     def __init__(self, name, text, ask_count, validation=lambda x: x is not None, post_process=lambda x: x):
@@ -32,9 +31,8 @@ class RepeatedQuestion(Question):
         self.ask_count = ask_count
 
     def ask(self):
-        logger.debug(f"REPEAT Question: {self.name}")
+        logger.debug("REPEAT Question: {}".format(self.name))
         return {self.name: list(map(lambda q: q.get_answer(), [self] * self.ask_count))}
-
 
 class BranchedQuestion(Question):
     def __init__(self, name, text, question_branches: list):
@@ -44,7 +42,7 @@ class BranchedQuestion(Question):
         self.question_branches = question_dict
 
     def ask(self):
-        logger.debug(f"BRANCH Question: {self.name}")
+        logger.debug("BRANCH Question: {}".format(self.name))
         ret = dict()
         branch_answer = self.get_answer()
         ret[self.name] = self.question_branches[branch_answer].ask()

--- a/question_framework/validation/validation.py
+++ b/question_framework/validation/validation.py
@@ -21,9 +21,9 @@ def x_hex_character_validation_gen(num_char: int) -> FunctionType:
     elif num_char < 0:
         raise TypeError("Expecting positive integer input")
     else:
-        num_char = f"{{{num_char}}}"
+        num_char = "{{{}}}.format(num_char)"
 
-    regex_str = f"^[a-fA-F0-9]{num_char}$"
+    regex_str = "^[a-fA-F0-9]{}$".format(num_char)
     return regex_match(regex_str)
 
 

--- a/question_framework/validation/validation.py
+++ b/question_framework/validation/validation.py
@@ -21,7 +21,7 @@ def x_hex_character_validation_gen(num_char: int) -> FunctionType:
     elif num_char < 0:
         raise TypeError("Expecting positive integer input")
     else:
-        num_char = "{{{0}}}.format(num_char)"
+        num_char = "{{{0}}}".format(num_char)
 
     regex_str = "^[a-fA-F0-9]{}$".format(num_char)
     return regex_match(regex_str)

--- a/question_framework/validation/validation.py
+++ b/question_framework/validation/validation.py
@@ -21,7 +21,7 @@ def x_hex_character_validation_gen(num_char: int) -> FunctionType:
     elif num_char < 0:
         raise TypeError("Expecting positive integer input")
     else:
-        num_char = "{{{}}}.format(num_char)"
+        num_char = "{{{0}}}.format(num_char)"
 
     regex_str = "^[a-fA-F0-9]{}$".format(num_char)
     return regex_match(regex_str)


### PR DESCRIPTION
Updated following files to use format methods rather than f-strings

from:
```
./question_framework/question/question.py:        logger.debug(f"Question: {self.name}")
./question_framework/question/question.py:        logger.debug(f"REPEAT Question: {self.name}")
./question_framework/question/question.py:        logger.debug(f"BRANCH Question: {self.name}")
./question_framework/validation/validation.py:        num_char = f"{{{num_char}}}"
./question_framework/validation/validation.py:    regex_str = f"^[a-fA-F0-9]{num_char}$"
```

to:
```
./question_framework/question/question.py:        logger.debug("Question: {}".format(self.name))
./question_framework/question/question.py:        logger.debug("REPEAT Question: {}".format(self.name))
./question_framework/question/question.py:        logger.debug("BRANCH Question: {}".format(self.name))
./question_framework/validation/validation.py:        num_char = "{{{}}}.format(num_char)"
./question_framework/validation/validation.py:    regex_str = "^[a-fA-F0-9]{}$".format(num_char)
```