### PR TITLE
Fix repeated question README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ John Doe
 `RepeatedQuestion` can be used to ask same question consecutively.
 
 ```python
-questions = [RepeatedQuestion("Password", "Your password:", 2)]
+questions = [RepeatedQuestion("Password", "Your password:", 3)]
 answers = ask(questions)
 print(answers)
 ```


### PR DESCRIPTION
Fixes repeated question README example. The example currently shows a RepeatedQuestion object with ask_count of 2 but output has ask_count of 3. This will reduce confusion. 